### PR TITLE
Allows dynamic buddy loading for MDSwiper

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from kivy.core.window import Window
 from kivymd.uix.dialog import MDDialog
 from kivymd.uix.tooltip import MDTooltip
 from kivymd.uix.snackbar import Snackbar
+from kivymd.uix.swiper import MDSwiperItem
 from datetime import datetime, timedelta
 from kivymd.uix.menu import MDDropdownMenu
 from kivymd.uix.picker import MDDatePicker
@@ -82,6 +83,14 @@ class ContentNavigationDrawer(MDBoxLayout):
     screen_manager = ObjectProperty()
     nav_drawer = ObjectProperty()
 
+class BuddySwiperItem(MDSwiperItem):
+    button_text = StringProperty()
+    image_source = StringProperty()
+
+    def __init__(self, button_text, image_source):
+        self.button_text = button_text
+        self.image_source = image_source
+        super().__init__()
 
 # Dialog Choice Confirmation (Single Choice)
 class ItemConfirm(OneLineAvatarIconListItem):
@@ -163,7 +172,16 @@ class FitnessApp(MDApp):
             activity_collection_df.to_csv('files/activity_collection.csv')
         helper_functions.get_activity_collection()
 
-        return Builder.load_string(main_kivy.KV)
+        build_app = Builder.load_string(main_kivy.KV)
+
+        swiper = build_app.ids["buddy_swiper"]
+
+        # TODO: Populate Buddys from loaded Data
+        swiper.add_widget(BuddySwiperItem("Bo", "images/Bo.jpg"))
+        swiper.add_widget(BuddySwiperItem("Penguin", "images/Penguin.jpg"))
+        swiper.add_widget(BuddySwiperItem("Robin", "images/Robin.jpg"))
+
+        return build_app
 
     def on_start(self):
         self.load_activity_collection_list()

--- a/main_kivy.py
+++ b/main_kivy.py
@@ -53,7 +53,26 @@ KV = '''
                     root.nav_drawer.set_state("close")
                     root.screen_manager.current = "settings"
                     root.screen_manager.transition.direction = 'left'
-   
+
+<BuddySwiperItem>
+    id: swiper_item
+    # These exist in the BuddySwiperItem class in main.py as StringProperties: image_source, button_text
+    
+    orientation: 'vertical'
+    FitImage:
+        source: swiper_item.image_source
+        radius: [20,]
+
+    MDLabel:
+        size_hint_y : 0.01
+        
+    MDRectangleFlatButton:
+        text: swiper_item.button_text
+        pos_hint: {"center_x": .5, "center_y": .5}
+        size_hint_y : 0.1
+        on_press: 
+            app.set_convo_info(swiper_item.button_text)
+
 ### THE APP ###                 
                     
 MDScreen:
@@ -451,57 +470,7 @@ MDScreen:
                         theme_text_color : 'Secondary'
                         
                     MDSwiper:
-                        
-                        MDSwiperItem:
-                            orientation: 'vertical'
-                            FitImage:
-                                source: "images/Bo.jpg"
-                                radius: [20,]
-                        
-                            MDLabel:
-                                size_hint_y : 0.01
-                                
-                            MDRectangleFlatButton:
-                                id: bo_button
-                                text: "Bo"
-                                pos_hint: {"center_x": .5, "center_y": .5}
-                                size_hint_y : 0.1
-                                on_press: 
-                                    app.set_convo_info(bo_button.text)
-                                
-                        MDSwiperItem:
-                            orientation: 'vertical'
-                            FitImage:
-                                source: "images/Penguin.jpg"
-                                radius: [20,]
-                            
-                            MDLabel:
-                                size_hint_y : 0.01
-                                
-                            MDRectangleFlatButton:
-                                id: penguin_button
-                                text: "Penguin"
-                                pos_hint: {"center_x": .5, "center_y": .5}
-                                size_hint_y : 0.1
-                                on_press: 
-                                    app.set_convo_info(penguin_button.text)
-                        
-                        MDSwiperItem:
-                            orientation: 'vertical'
-                            FitImage:
-                                source: "images/Robin.jpg"
-                                radius: [20,]
-                            
-                            MDLabel:
-                                size_hint_y : 0.01
-                        
-                            MDRectangleFlatButton:
-                                id: robin_button
-                                text: "Robin"
-                                pos_hint: {"center_x": .5, "center_y": .5}
-                                size_hint_y : 0.1
-                                on_press: 
-                                    app.set_convo_info(robin_button.text)
+                        id: buddy_swiper
             
             # Buddy Screen Subscreen : Buddy Detail & Choose a chat                        
             MDScreen:


### PR DESCRIPTION
Fixing Issue - (Problem was noted in `README.md` as " the overview of buddies in the MDSwiper, no possibility could be found to read them in dynamically")

The following changes were made:
- Allows for dynamic loading of Buddies for the MDSwiper Component

Only if you can apply it to the problem at hand:
How did we make that mistake and how can we learn from it and your changes?
- This PR basically combines Id referencing of the MDSwiper Widget (see [here](https://kivy.org/doc/stable/guide/lang.html#accessing-widgets-defined-inside-kv-lang-in-your-python-code)) with [Widget Referencing](https://kivy.org/doc/stable/guide/lang.html#referencing-widgets) and a custom SwiperItem Class. I guess with this PR as an example it will be possible to make more features cleaner or dynamic in the future.
